### PR TITLE
feat: restrict GitHub Releases to final version patterns

### DIFF
--- a/.github/workflows/autotagger.yml
+++ b/.github/workflows/autotagger.yml
@@ -29,7 +29,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # 1. Get the latest STABLE tag for this project
-          LATEST_TAG=$(git tag -l "lib/v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n 1)
+          # We use git tag -l and then filter with grep -E for strict Regex matching.
+          # [0-9]+ ensures at least one digit, and $ ensures no trailing beta/rc suffixes.
+          LATEST_TAG=$(git tag -l "lib/v*" --sort=-v:refname | grep -E "^lib/v[0-9]+\.[0-9]+\.[0-9]+$" | head -n 1)
           if [ -z "$LATEST_TAG" ]; then LATEST_TAG="lib/v0.0.0"; fi
           echo "Latest stable library tag: $LATEST_TAG"
           
@@ -56,7 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # 1. Get the latest STABLE tag for this project
-          LATEST_TAG=$(git tag -l "bot/v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n 1)
+          LATEST_TAG=$(git tag -l "bot/v*" --sort=-v:refname | grep -E "^bot/v[0-9]+\.[0-9]+\.[0-9]+$" | head -n 1)
           if [ -z "$LATEST_TAG" ]; then LATEST_TAG="bot/v0.0.0"; fi
           echo "Latest stable bot tag: $LATEST_TAG"
           

--- a/.github/workflows/autotagger.yml
+++ b/.github/workflows/autotagger.yml
@@ -67,21 +67,4 @@ jobs:
             echo "No changes requiring a bot version bump."
           fi
 
-      - name: Cleanup Beta Tags
-        if: always()
-        run: |
-          echo "Fetching all tags to identify candidates for cleanup..."
-          git fetch --tags origin
-          
-          # We only want to delete beta tags that are REACHABLE from the current master (HEAD)
-          # this ensures we don't accidentally delete beta tags from other active branches.
-          BETA_TAGS=$(git tag -l "*beta*" --merged HEAD)
-          
-          if [ -n "$BETA_TAGS" ]; then
-            for tag in $BETA_TAGS; do
-              echo "Deleting merged beta tag: $tag"
-              git push origin --delete "$tag"
-            done
-          else
-            echo "No merged beta tags to cleanup."
-          fi
+

--- a/.github/workflows/autotagger.yml
+++ b/.github/workflows/autotagger.yml
@@ -41,8 +41,8 @@ jobs:
           # so we ensure it knows we are starting from our LATEST_TAG.
           NEXT_TAG=$(git cliff "$LATEST_TAG..HEAD" --bump --include-path "lib/**" --tag-pattern "lib/v[0-9]+\.[0-9]+\.[0-9]+$" --unreleased --strip all)
           
-          # 3. Validation and Push
-          if [ -n "$NEXT_TAG" ] && [ "$NEXT_TAG" != "$LATEST_TAG" ] && [[ "$NEXT_TAG" =~ ^lib/v[0-9] ]]; then
+          # 3. Validation and Push (Strict check for X.Y.Z format)
+          if [ -n "$NEXT_TAG" ] && [ "$NEXT_TAG" != "$LATEST_TAG" ] && [[ "$NEXT_TAG" =~ ^lib/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "New library version detected: $NEXT_TAG"
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -65,7 +65,7 @@ jobs:
           # 2. Calculate next version
           NEXT_TAG=$(git cliff "$LATEST_TAG..HEAD" --bump --include-path "bot/**" --tag-pattern "bot/v[0-9]+\.[0-9]+\.[0-9]+$" --unreleased --strip all)
           
-          if [ -n "$NEXT_TAG" ] && [ "$NEXT_TAG" != "$LATEST_TAG" ] && [[ "$NEXT_TAG" =~ ^bot/v[0-9] ]]; then
+          if [ -n "$NEXT_TAG" ] && [ "$NEXT_TAG" != "$LATEST_TAG" ] && [[ "$NEXT_TAG" =~ ^bot/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "New bot version detected: $NEXT_TAG"
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/autotagger.yml
+++ b/.github/workflows/autotagger.yml
@@ -28,14 +28,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LATEST_TAG=$(git tag -l "lib/v*" --sort=-v:refname | head -n 1)
+          # 1. Get the latest STABLE tag for this project
+          LATEST_TAG=$(git tag -l "lib/v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n 1)
           if [ -z "$LATEST_TAG" ]; then LATEST_TAG="lib/v0.0.0"; fi
-          echo "Latest library tag: $LATEST_TAG"
+          echo "Latest stable library tag: $LATEST_TAG"
           
-          # We need to make sure NEXT_TAG includes the base version
-          NEXT_TAG=$(git cliff --bump --include-path "lib/**" --tag-pattern "lib/v[0-9]*.[0-9]*.[0-9]*" --unreleased --strip all)
+          # 2. Calculate next version. 
+          # We use --unreleased to consider commits since last tag.
+          # If no stable tags exist, git-cliff might fail prefix validation, 
+          # so we ensure it knows we are starting from our LATEST_TAG.
+          NEXT_TAG=$(git cliff "$LATEST_TAG..HEAD" --bump --include-path "lib/**" --tag-pattern "lib/v[0-9]+\.[0-9]+\.[0-9]+$" --unreleased --strip all)
           
-          # Check if NEXT_TAG matches the cleaned pattern and is not the same as LATEST_TAG
+          # 3. Validation and Push
           if [ -n "$NEXT_TAG" ] && [ "$NEXT_TAG" != "$LATEST_TAG" ] && [[ "$NEXT_TAG" =~ ^lib/v[0-9] ]]; then
             echo "New library version detected: $NEXT_TAG"
             git config user.name "github-actions[bot]"
@@ -43,7 +47,7 @@ jobs:
             git tag "$NEXT_TAG"
             git push origin "$NEXT_TAG"
           else
-            echo "No changes requiring a library version bump."
+            echo "No changes requiring a library version bump (Current: $LATEST_TAG)."
           fi
 
       - name: Tag Bot
@@ -51,11 +55,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LATEST_TAG=$(git tag -l "bot/v*" --sort=-v:refname | head -n 1)
+          # 1. Get the latest STABLE tag for this project
+          LATEST_TAG=$(git tag -l "bot/v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n 1)
           if [ -z "$LATEST_TAG" ]; then LATEST_TAG="bot/v0.0.0"; fi
-          echo "Latest bot tag: $LATEST_TAG"
+          echo "Latest stable bot tag: $LATEST_TAG"
           
-          NEXT_TAG=$(git cliff --bump --include-path "bot/**" --tag-pattern "bot/v[0-9]*.[0-9]*.[0-9]*" --unreleased --strip all)
+          # 2. Calculate next version
+          NEXT_TAG=$(git cliff "$LATEST_TAG..HEAD" --bump --include-path "bot/**" --tag-pattern "bot/v[0-9]+\.[0-9]+\.[0-9]+$" --unreleased --strip all)
           
           if [ -n "$NEXT_TAG" ] && [ "$NEXT_TAG" != "$LATEST_TAG" ] && [[ "$NEXT_TAG" =~ ^bot/v[0-9] ]]; then
             echo "New bot version detected: $NEXT_TAG"
@@ -64,7 +70,7 @@ jobs:
             git tag "$NEXT_TAG"
             git push origin "$NEXT_TAG"
           else
-            echo "No changes requiring a bot version bump."
+            echo "No changes requiring a bot version bump (Current: $LATEST_TAG)."
           fi
 
 

--- a/.github/workflows/beta-tagger.yml
+++ b/.github/workflows/beta-tagger.yml
@@ -37,21 +37,22 @@ jobs:
             TAG_NAME="$PROJECT/v$CUSTOM"
           else
             # Find base version (latest clean tag in HISTORY of current branch/HEAD)
-            # We use --merged HEAD to ensure the tag is relevant to current code
-            BASE_TAG=$(git tag -l "$PROJECT/v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname --merged HEAD | grep -v "beta" | head -n 1)
+            # We use grep -E for strict stable version matching (X.Y.Z)
+            BASE_TAG=$(git tag -l "$PROJECT/v*" --sort=-v:refname --merged HEAD | grep -E "^$PROJECT/v[0-9]+\.[0-9]+\.[0-9]+$" | head -n 1)
             
             if [ -z "$BASE_TAG" ]; then 
               # Fallback to latest global tag if no tag in history
-              BASE_TAG=$(git tag -l "$PROJECT/v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | grep -v "beta" | head -n 1 || echo "$PROJECT/v0.0.0")
+              BASE_TAG=$(git tag -l "$PROJECT/v*" --sort=-v:refname | grep -E "^$PROJECT/v[0-9]+\.[0-9]+\.[0-9]+$" | head -n 1 || echo "$PROJECT/v0.0.0")
             fi
             
             echo "Base version tag found: $BASE_TAG"
             BASE_VERSION=${BASE_TAG#$PROJECT/v}
             
             # Find latest beta for this base version across all branches
-            LATEST_BETA=$(git tag -l "$PROJECT/v$BASE_VERSION-beta*" --sort=-v:refname | head -n 1)
+            # Matches format X.Y.Z-betaN
+            LATEST_BETA=$(git tag -l "$PROJECT/v$BASE_VERSION-beta*" --sort=-v:refname | grep -E "^$PROJECT/v$BASE_VERSION-beta[0-9]+$" | head -n 1)
             
-            if [ -z "$LATEST_BETA" ] || [[ ! "$LATEST_BETA" =~ -beta[0-9]+$ ]]; then
+            if [ -z "$LATEST_BETA" ]; then
               NEXT_NUM=1
             else
               # Extract number after 'beta'

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -22,8 +22,13 @@ jobs:
         run: |
           TAG_NAME=${GITHUB_REF#refs/tags/}
           VERSION=${TAG_NAME#bot/v}
+          IS_STABLE_VERSION="false"
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            IS_STABLE_VERSION="true"
+          fi
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "IS_STABLE_VERSION=$IS_STABLE_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -51,6 +56,7 @@ jobs:
             sheviak/transmissionhub-telegram-bot:${{ steps.prep.outputs.VERSION }}
 
       - name: Generate Changelog
+        if: steps.prep.outputs.IS_STABLE_VERSION == 'true'
         uses: orhun/git-cliff-action@v4
         id: git-cliff
         with:
@@ -60,7 +66,7 @@ jobs:
           OUTPUT: CHANGELOG.md
 
       - name: Create Release
-        if: ${{ !contains(steps.prep.outputs.VERSION, '-') }}
+        if: steps.prep.outputs.IS_STABLE_VERSION == 'true'
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.git-cliff.outputs.content }}

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -22,8 +22,13 @@ jobs:
         run: |
           TAG_NAME=${GITHUB_REF#refs/tags/}
           VERSION=${TAG_NAME#lib/v}
+          IS_STABLE_VERSION="false"
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            IS_STABLE_VERSION="true"
+          fi
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "IS_STABLE_VERSION=$IS_STABLE_VERSION" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -36,6 +41,7 @@ jobs:
         run: dotnet nuget push out/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
 
       - name: Generate Changelog
+        if: steps.prep.outputs.IS_STABLE_VERSION == 'true'
         uses: orhun/git-cliff-action@v4
         id: git-cliff
         with:
@@ -45,7 +51,7 @@ jobs:
           OUTPUT: CHANGELOG.md
 
       - name: Create Release
-        if: ${{ !contains(steps.prep.outputs.VERSION, '-') }}
+        if: steps.prep.outputs.IS_STABLE_VERSION == 'true'
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.git-cliff.outputs.content }}

--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,4 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+issues/

--- a/cliff.toml
+++ b/cliff.toml
@@ -43,6 +43,7 @@ commit_parsers = [
   { message = "^test", group = "🧪 Tests", skip = true },
   { message = "^docs", group = "📖 Documentation", skip = true },
   { message = "^ci", group = "⚙️ CI", skip = true },
+  { message = "^chore\\(deps\\)", group = "📦 Dependencies" },
   { message = "^chore", group = "🔧 Chore", skip = true },
   { message = "^style", group = "🎨 Style", skip = true },
   { message = "^build", group = "🏗️ Build", skip = true },

--- a/cliff.toml
+++ b/cliff.toml
@@ -49,7 +49,7 @@ commit_parsers = [
   { message = "^wip", skip = true },
 ]
 filter_commits = true
-tag_pattern = "(lib|bot)/v[0-9].*"
+tag_pattern = "(lib|bot)/v[0-9]+\\.[0-9]+\\.[0-9]+$"
 
 [git.remote]
 name = "origin"


### PR DESCRIPTION
Closes #20. This PR updates the release-lib and release-bot workflows to gate GitHub Release creation and changelog generation, ensuring they only trigger for final version tags (X.Y.Z). Publishing to NuGet and Docker remains enabled for all tags.